### PR TITLE
Clarify explanation for require_certificate option

### DIFF
--- a/mosquitto/DOCS.md
+++ b/mosquitto/DOCS.md
@@ -78,7 +78,8 @@ A file containing the private key. Place this file in the Home Assistant `ssl` f
 
 ### Option: `require_certificate`
 
-If set to `true` encryption will be enabled using the cert- and keyfile options.
+If set to `true`, the client must provide a valid certificate in order to connect successfully.  
+If set to `false`, the SSL/TLS component of the client will verify the server but there is no requirement for the client to provide anything for the server, authentication is limited to the MQTT username/password.
 
 ### Option: `debug`
 


### PR DESCRIPTION
Hey,

I was setting up this add-on on my home-assistant, and I couldn't figure out why I couldn't connect via SSL/TLS. I enabled the debug logs, nothing was showing, just `Error: The connection was lost` on the client side 🤷‍♂️

Then I looked in the code of this repo, and tried to understand what the `require_certificate` option really did. That led me to the [documentation of mosquito](https://mosquitto.org/man/mosquitto-conf-5.html) and I read this:
> When using certificate based encryption there are three options that affect authentication. The first is require_certificate, which may be set to true or false. If false, the SSL/TLS component of the client will verify the server but there is no requirement for the client to provide anything for the server: authentication is limited to the MQTT built in username/password. If require_certificate is true, the client must provide a valid certificate in order to connect successfully.

The original explanation on this project was
> If set to `true` encryption will be enabled using the cert- and keyfile options.

This led me to believe that it had to be set to `true` for mosquito to provide an encrypted connection. But in reality, leaving it to `false` would still offer encryption, it just wouldn't authenticate the client (which tbh I'm not 100% sure what it means).

I figured I'd submit a PR to clarify that. I copy pasted the definition from the [official mosquito doc](https://mosquitto.org/man/mosquitto-conf-5.html) (with some edit to make it look nice like the other options).

I hope that helps 👍